### PR TITLE
Fixes a casing issue around typescript Objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-docgen",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.3",
   "description": "Low level library for creating decscriptions of angular components",
   "main": "dist/parser.js",
   "types": "dist/parser.d.ts",

--- a/src/handlers/propertyDeclarationHandler.ts
+++ b/src/handlers/propertyDeclarationHandler.ts
@@ -40,9 +40,11 @@ const getPropertyType = (node: ts.PropertyDeclaration): any => {
 const getPropertyValue = (node: ts.PropertyDeclaration, type: any): any => {
   const value = node.initializer.getText();
 
-  switch(type) {
-    case 'Number': return parseInt(value, 10);
-    case 'Boolean': return (value === 'true') ? true : false;
+  if(!type) return value.replace(/"/g, '');
+
+  switch(type.toLowerCase()) {
+    case 'number': return parseInt(value, 10);
+    case 'boolean': return (value === 'true') ? true : false;
     default: return value.replace(/"/g, '');
   }
 }


### PR DESCRIPTION
You should generally always use `boolean` over `Boolean` anyway